### PR TITLE
feat: requestIdleCallback for higher panning performance

### DIFF
--- a/packages/client/src/layers/phaser/config.ts
+++ b/packages/client/src/layers/phaser/config.ts
@@ -191,7 +191,7 @@ export const phaserConfig = {
     pinchSpeed: 1 / 32,
     wheelSpeed: 1,
     maxZoom: 4,
-    minZoom: 1 / 128,
+    minZoom: 1 / 80,
   }),
   cullingChunkSize: TILE_HEIGHT * 16,
 };

--- a/packages/client/src/layers/phaser/config.ts
+++ b/packages/client/src/layers/phaser/config.ts
@@ -59,7 +59,7 @@ export const phaserConfig = {
           },
         }),
         [Maps.X8]: defineMapConfig({
-          chunkSize: TILE_WIDTH * 64 * 16, // tile size * tile amount
+          chunkSize: TILE_WIDTH * 64 * 8, // tile size * tile amount
           tileWidth: TILE_WIDTH * 8,
           tileHeight: TILE_HEIGHT * 8,
           backgroundTile: [0],
@@ -73,7 +73,7 @@ export const phaserConfig = {
           },
         }),
         [Maps.X16]: defineMapConfig({
-          chunkSize: TILE_WIDTH * 64 * 64, // tile size * tile amount
+          chunkSize: TILE_WIDTH * 64 * 16, // tile size * tile amount
           tileWidth: TILE_WIDTH * 16,
           tileHeight: TILE_HEIGHT * 16,
           backgroundTile: [0],
@@ -87,7 +87,7 @@ export const phaserConfig = {
           },
         }),
         [Maps.Heat]: defineMapConfig({
-          chunkSize: TILE_WIDTH * 64 * 64, // tile size * tile amount
+          chunkSize: TILE_WIDTH * 64 * 16, // tile size * tile amount
           tileWidth: TILE_WIDTH * 16,
           tileHeight: TILE_HEIGHT * 16,
           backgroundTile: [0],
@@ -139,7 +139,7 @@ export const phaserConfig = {
           },
         }),
         [Maps.HeightX8]: defineMapConfig({
-          chunkSize: TILE_WIDTH * 64 * 16, // tile size * tile amount
+          chunkSize: TILE_WIDTH * 64 * 8, // tile size * tile amount
           tileWidth: TILE_WIDTH * 8,
           tileHeight: TILE_HEIGHT * 8,
           backgroundTile: [0],
@@ -152,7 +152,7 @@ export const phaserConfig = {
           },
         }),
         [Maps.HeightX16]: defineMapConfig({
-          chunkSize: TILE_WIDTH * 64 * 64, // tile size * tile amount
+          chunkSize: TILE_WIDTH * 64 * 16, // tile size * tile amount
           tileWidth: TILE_WIDTH * 16,
           tileHeight: TILE_HEIGHT * 16,
           backgroundTile: [0],
@@ -188,7 +188,7 @@ export const phaserConfig = {
   }),
   cameraConfig: defineCameraConfig({
     phaserSelector: "phaser-game",
-    pinchSpeed: 1 / 32,
+    pinchSpeed: 1 / 16,
     wheelSpeed: 1,
     maxZoom: 4,
     minZoom: 1 / 128,

--- a/packages/client/src/layers/phaser/config.ts
+++ b/packages/client/src/layers/phaser/config.ts
@@ -188,7 +188,7 @@ export const phaserConfig = {
   }),
   cameraConfig: defineCameraConfig({
     phaserSelector: "phaser-game",
-    pinchSpeed: 1 / 16,
+    pinchSpeed: 1 / 32,
     wheelSpeed: 1,
     maxZoom: 4,
     minZoom: 1 / 128,

--- a/packages/client/src/layers/phaser/createPhaserLayer.ts
+++ b/packages/client/src/layers/phaser/createPhaserLayer.ts
@@ -28,7 +28,7 @@ export async function createPhaserLayer(network: NetworkLayer) {
   world.registerDisposer(disposePhaser);
   scenes.Main.camera.setZoom(1 / 2);
 
-  const chunks = createChunks(scenes.Main.camera.worldView$, TILE_HEIGHT * 64, TILE_HEIGHT * 64); // Tile size in pixels * Tiles per chunk
+  const chunks = createChunks(scenes.Main.camera.worldView$, TILE_HEIGHT * 64, TILE_HEIGHT * 16); // Tile size in pixels * Tiles per chunk
 
   // --- API -----------------------------------------------------------------------
   const { Main, X2, X4, X8, X16, Height, HeightX2, HeightX4, HeightX8, HeightX16 } = scenes.Main.maps;

--- a/packages/client/src/layers/phaser/systems/createMapSystem.ts
+++ b/packages/client/src/layers/phaser/systems/createMapSystem.ts
@@ -1,4 +1,4 @@
-import { defineComponent, defineComponentSystem, defineRxSystem, getComponentValue } from "@latticexyz/recs";
+import { defineRxSystem, getComponentValue } from "@latticexyz/recs";
 import { NetworkLayer } from "../../network";
 import { Maps, PhaserLayer } from "../types";
 import { HeightMapTiles } from "../assets/tilesets/opcraftTileset";
@@ -25,6 +25,7 @@ export function createMapSystem(context: PhaserLayer, network: NetworkLayer) {
     maps,
     scenes: {
       Main: {
+        phaserScene,
         maps: { Heat },
       },
     },
@@ -37,6 +38,8 @@ export function createMapSystem(context: PhaserLayer, network: NetworkLayer) {
   chunks.addedChunks$.subscribe(addedChunks$);
   const newTile$ = new Subject<Coord>();
 
+  // Prevent redrawing the entire map on each tick
+  (phaserScene.game.renderer.config as any).clearBeforeRender = false;
   /**
    * Draw the given tile at the given coord on the given layer on all maps
    */
@@ -54,21 +57,26 @@ export function createMapSystem(context: PhaserLayer, network: NetworkLayer) {
    * and draw it on the phaser tilemap
    */
   defineRxSystem(world, newTile$, async ({ x, y: z }) => {
-    const highestTiles = getHighestTilesAt({ x, z, perlin, Position, Position2D, Item });
-    if (!highestTiles) return;
+    requestIdleCallback(
+      () => {
+        const highestTiles = getHighestTilesAt({ x, z, perlin, Position, Position2D, Item });
+        if (!highestTiles) return;
 
-    const { y, foregroundTile, backgroundTile } = highestTiles;
+        const { y, foregroundTile, backgroundTile } = highestTiles;
 
-    const heightTile = HeightMapTiles[Math.max(-8, Math.min(8, Math.floor(y / 8)))];
-    if (heightTile != null) {
-      drawTile(x, z, heightTile, maps.height);
-    }
-    if (foregroundTile != null) {
-      drawTile(x, z, foregroundTile, maps.terrain, "Foreground");
-    }
-    if (backgroundTile != null) {
-      drawTile(x, z, backgroundTile, maps.terrain, "Background");
-    }
+        const heightTile = HeightMapTiles[Math.max(-8, Math.min(8, Math.floor(y / 8)))];
+        if (heightTile != null) {
+          drawTile(x, z, heightTile, maps.height);
+        }
+        if (foregroundTile != null) {
+          drawTile(x, z, foregroundTile, maps.terrain, "Foreground");
+        }
+        if (backgroundTile != null) {
+          drawTile(x, z, backgroundTile, maps.terrain, "Background");
+        }
+      },
+      { timeout: 3000 }
+    );
   });
 
   /**

--- a/packages/client/src/layers/phaser/systems/createMapSystem.ts
+++ b/packages/client/src/layers/phaser/systems/createMapSystem.ts
@@ -38,7 +38,7 @@ export function createMapSystem(context: PhaserLayer, network: NetworkLayer) {
   chunks.addedChunks$.subscribe(addedChunks$);
   const newTile$ = new Subject<Coord>();
 
-  // Prevent redrawing the entire map on each tick
+  // Prevent clearing the entire map before each redraw (before each tick)
   (phaserScene.game.renderer.config as any).clearBeforeRender = false;
   /**
    * Draw the given tile at the given coord on the given layer on all maps


### PR DESCRIPTION
Spent a lot of time this morning trying to improve the performance of panning around the map. `requestIdleCallback` helps increasing the perceived performance (because camera movement doesn't get blocked by computing tiles), but in zoom levels below ~1/64 `requestIdleCallback` is not called anymore unless if forced by the timeout option.

This is because phaser redraws the tilemap each frame, and each redraw takes longer than the target frame duration, so there is no idle time in which the callback could be called.

<img width="811" alt="CleanShot 2022-11-15 at 15 28 03@2x" src="https://user-images.githubusercontent.com/89248902/201959167-271345d4-cc0d-4eed-bec2-61d17e871339.png">

It seems like redrawing the entire tilemap every frame is a huge waste, but I wasn't able to prevent phaser from doing so.
Things I've tried:
- manually setting phaser's target fps to a low number -> caused less redraws, but also the camera movement is bound by the fps, so everything looks very laggy
- overriding the tilemap's internal `cullCallback` function to only draw each tile once -> map flashes with correct texture for a frame but then stays black (seems like phaser still redrew every tile every frame, and if it wasn't returned by the culling method it was left black)
- throttle rerendering the tilemap to less than once per frame -> made it look and feel more laggy

The current state in this PR is requesting an idle callback to render tiles, but also setting a timeout of 3000ms. This makes panning in zoom levels above 1/64 smooth, while panning in zoom levels below 1/64 is smooth for ~3000ms, and then the map has to catch up computing.

This PR also limits the min zoom to 1/80, which seems to be an acceptable value where panning stays performant while the map state is being computed (because with this zoom value phaser is able to redraw the entire tilemap within a frame and the main thread has some time left to execute the requested idle callback).
